### PR TITLE
postcss as a peer dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ is 671 bytes:
 <script>cssBlankPseudo(document)</script>
 ```
 
+**Note**: you should include postcss@7 into devDependencies of your project manually. postcss tooling packages require it as a peer and does not install it to avoid swallowing the typical node_modules directory.
+
 ## How it works
 
 The [PostCSS plugin](README-POSTCSS.md) clones rules containing `:blank`,

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "dependencies": {
-    "postcss": "^7.0.17"
+  "peerDependencies": {
+    "postcss": "7"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
@@ -53,6 +53,7 @@
     "babel-eslint": "^10.0.1",
     "cross-env": "^5.2.0",
     "eslint": "^5.16.0",
+    "postcss": "^7.0.17",
     "postcss-tape": "^5.0.0",
     "pre-commit": "^1.2.2",
     "rollup": "^1.14.6",


### PR DESCRIPTION
every project, that use postcss tooling has a postcss self

because every package requires postcss himself, my project has about 10 postcss installations every with own version.